### PR TITLE
if ( $this->options['debug_mode'] )

### DIFF
--- a/frontend/abstract-class-tracking.php
+++ b/frontend/abstract-class-tracking.php
@@ -474,7 +474,7 @@ abstract class Yoast_GA_Tracking {
 	 * @return bool
 	 */
 	protected function debug_mode() {
-		if ( $this->options['debug_mode'] === 1 ) {
+		if ( $this->options['debug_mode'] ) {
 			/* translators %1$s is the product name 'Google Analytics by Yoast'. %2$s displays the plugin version the website uses and a link to the plugin on Yoast.com */
 			echo '<!-- ' . sprintf( __( 'This site uses the %1$s plugin version %2$s', 'google-analytics-for-wordpress' ), 'Google Analytics by Yoast', GAWP_VERSION . ' - https://yoast.com/wordpress/plugins/google-analytics/' ) . ' -->';
 


### PR DESCRIPTION
Comparison `=== 1` fails because it's either a string `"1"` or number `0`. Suggesting just boolean checking.