### PR TITLE
Missing Post-Type Parameter

### DIFF
--- a/assets/lib/pandora/class-am-notification.php
+++ b/assets/lib/pandora/class-am-notification.php
@@ -84,7 +84,8 @@ if ( ! class_exists( 'AM_Notification' ) ) {
 		 */
 		public function custom_post_type() {
 			register_post_type( 'amn_' . $this->plugin, array(
-				'supports' => false
+				'supports' => false,
+				'can_export' => false
 			) );
 		}
 


### PR DESCRIPTION
The post-type shows up in "/wp-admin/export.php" as a normal post because there are no labels defined. It seems it could be also hidden in export-dialog.